### PR TITLE
GT3VolExtractor: Support plain RoFS magic

### DIFF
--- a/GT3VOLExtractor/GT3VOLExtractor/App.config
+++ b/GT3VOLExtractor/GT3VOLExtractor/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/GT3VOLExtractor/GT3VOLExtractor/GT3VOLExtractor.csproj
+++ b/GT3VOLExtractor/GT3VOLExtractor/GT3VOLExtractor.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GT3.VOLExtractor</RootNamespace>
     <AssemblyName>GT3VOLExtractor</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
For completeness, GT4P (at least) allows reading a volume with a plain RoFS magic, where file names aren't cheaply encrypted.
Added support for that.